### PR TITLE
added string data sysex message support

### DIFF
--- a/src/firmata/core.clj
+++ b/src/firmata/core.clj
@@ -242,6 +242,12 @@
     {:type :analog-mappings
      :mappings mappings}))
 
+(defmethod read-sysex-event STRING_DATA
+  [in]
+  (let [data (consume-sysex in "" #(str %1 (char %2)))]
+    {:type :string-data
+     :data data}))
+
 (defmethod read-sysex-event :default
   [in]
   (let [values (consume-sysex in '[] #(conj %1 %2))]

--- a/test/firmata/test/core.clj
+++ b/test/firmata/test/core.clj
@@ -127,6 +127,14 @@
                     5 19} (:mappings event))))
           (is (= "Expected event" "but was no event"))))
 
+      (testing "read string data"
+        (@handler (create-in-stream 0xF0 0x71 "Hello World" 0xF7))
+        (if-let [event (<!! evt-chan)]
+          (do
+            (is (= :string-data (:type event)))
+            (is (= "Hello World" (:data event))))
+          (is (= "Expected event" "but was no event"))))
+
       (testing "read i2c-reply"
         (@handler (create-in-stream 0xF0 0x77
                                     0xA 0x0 ; slave address


### PR DESCRIPTION
Added support for sysex `STRING_DATA` messages. I also wrote a passing test case, and confirmed it works using a arduino.

SN: Is there any reason why `read-sysex-event` is private? I'd like to extend it (using `defmethod`) and add my own handlers without forking the project. See [src/firmata/core.clj#L181](https://github.com/peterschwarz/clj-firmata/blob/master/src/firmata/core.clj#L181)
