### PR TITLE
Changed key sysex methods to be public

### DIFF
--- a/src/firmata/core.clj
+++ b/src/firmata/core.clj
@@ -148,7 +148,7 @@
       (recur (.read in)
              (accumulator result current-value)))))
 
-(defn- consume-sysex
+(defn consume-sysex
   "Consumes bytes until the end of a SysEx response."
   [in initial accumulator]
   (consume-until SYSEX_END in initial accumulator))
@@ -216,7 +216,7 @@
      :value value})
   )
 
-(defn- read-two-byte-data
+(defn read-two-byte-data
   [in]
   (loop [result []
          current-byte (.read in)]


### PR DESCRIPTION
I tried to get fancy and add a PR to an existing issue, but I didn't get it quite right. This is a preliminary PR for #3. I realise it will change soon, but it will really help me. 

If you can push this into master and release it, I can then release the dashboard without having to use a forked clj-firmata dependency. No rush, but when you get a chance. Thanks :)
