### PR TITLE
Fix clojurescript clojure.string dependency in core.cljx

### DIFF
--- a/src/cljx/firmata/core.cljx
+++ b/src/cljx/firmata/core.cljx
@@ -9,7 +9,10 @@
             [clojure.core.async :as a :refer [go chan >! <! <!!]]
 
             #+cljs
-            [cljs.core.async    :as a :refer [chan >! <!]])
+            [cljs.core.async    :as a :refer [chan >! <!]]
+
+            #+cljs
+            [clojure.string])
   #+cljs
   (:require-macros [cljs.core.async.macros :refer [go]]))
 


### PR DESCRIPTION
When using `cli-firmata v2.0.0` in the TestDrive Dashboard project, I get the following warning during Clojurescript compilation.

`WARNING: Use of undeclared Var clojure.string/join at line 171 file:/Users/blakejakopovic/.m2/repository/clj-firmata/clj-firmata/2.0.0/clj-firmata-2.0.0.jar!/firmata/core.cljs`

For Clojurescript, you need to require `clojure.string` specifically before using it. I couldn't reproduce the warning during `clj-firmata` compilation, however I tested it against TestDrive, and it fixed the warning.
