### PR TITLE
Implement linux arduino port detection.

### DIFF
--- a/src/cljx/firmata/util.cljx
+++ b/src/cljx/firmata/util.cljx
@@ -66,7 +66,7 @@
 (defn arduino-port?
   "Compares port name with known arduino port formats"
   [port-name]
-  (re-matches #"^(/dev/)?(tty|cu)\.usbmodem.*$" port-name)) ;; Older boards
+  (re-matches #"^(/dev/)?(tty|cu)(\.usbmodem|ACM).*$" port-name)) ;; Older boards
 
 #+clj
 (defn detect-arduino-port

--- a/test/cljx/firmata/test/util.cljx
+++ b/test/cljx/firmata/test/util.cljx
@@ -72,12 +72,15 @@
     (is (arduino-port? "tty.usbmodem1234"))
     (is (arduino-port? "cu.usbmodem0121"))
     (is (arduino-port? "/dev/tty.usbmodem54321"))
-    (is (arduino-port? "/dev/cu.usbmodem0121")))
+    (is (arduino-port? "/dev/cu.usbmodem0121"))
+    (is (arduino-port? "/dev/ttyACM0"))
+    (is (arduino-port? "ttyACM1")))
 
   (testing "no matches"
     (is (nil? (arduino-port? "usbmodem1234")))
     (is (nil? (arduino-port? "not.usbmodem1234")))
-    (is (nil? (arduino-port? "/tmp/tty.usbmodem1234")))))
+    (is (nil? (arduino-port? "/tmp/tty.usbmodem1234")))
+    (is (nil? (arduino-port? "/dev/ttyS1")))))
 
 
 #+cljs


### PR DESCRIPTION
Arduino devices appear in /dev as ttyACM0 in linux
